### PR TITLE
Add a clean content flag

### DIFF
--- a/syrinx/cli.py
+++ b/syrinx/cli.py
@@ -9,6 +9,8 @@ def get_args():
     parser = argparse.ArgumentParser()
 
     parser.add_argument("root_dir", type=str, help="Location of root directory to build from")
+    parser.add_argument("-c", "--clean", action="store_true", 
+                        help="Remove existing dynamic content files")
 
     return parser.parse_args()
 
@@ -17,7 +19,7 @@ def main():
 
     root_dir = abspath(args.root_dir)
     assert isdir(root_dir)
-    preprocess(root_dir)
+    preprocess(root_dir, clean=args.clean)
     root = read(root_dir)
     build(root, root_dir)
     print('done.')

--- a/syrinx/cli.py
+++ b/syrinx/cli.py
@@ -2,11 +2,20 @@ from syrinx.build import build
 from syrinx.read import read
 from syrinx.preprocess import preprocess
 from os.path import abspath, isdir
-import sys
+import argparse
 
+
+def get_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("root_dir", type=str, help="Location of root directory to build from")
+
+    return parser.parse_args()
 
 def main():
-    root_dir = abspath(sys.argv[1])
+    args = get_args()
+
+    root_dir = abspath(args.root_dir)
     assert isdir(root_dir)
     preprocess(root_dir)
     root = read(root_dir)

--- a/syrinx/preprocess.py
+++ b/syrinx/preprocess.py
@@ -9,7 +9,7 @@ Each column will be converted to a variable in the front matter
 from __future__ import annotations
 from typing import TYPE_CHECKING, Dict
 from os.path import join, isdir, basename
-from os import makedirs
+from os import makedirs, remove
 from glob import glob
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pandas import read_csv
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from jinja2 import Template
 
 
-def preprocess(root_dir: str) -> None:
+def preprocess(root_dir: str, clean: bool = False) -> None:
 
     assert isdir(root_dir)
 
@@ -44,6 +44,10 @@ def preprocess(root_dir: str) -> None:
 
         collection_dir = join(root_dir, 'content', archetype_name)
         makedirs(collection_dir, exist_ok=True)
+
+        if clean:
+            stale_content = glob("*.md", root_dir=collection_dir)
+            [remove(join(collection_dir, filename)) for filename in stale_content if "index" not in filename]
 
         df = read_csv(fpath, sep='\t', index_col=0)
 


### PR DESCRIPTION
This replaces argument handling using `sys` with `argparse`, which makes it easier to create and handle optional arguments.

Then modifies pre-processing so that if the optional flag `--clean` or `-c` is set then the dynamic content generated (i.e. anything other than `index.md`) is removed before rebuilding the site.

Could easily be flipped to do this by default and have the flag to stop it (e.g. `--keep-content` ). I went for this as an optional action because the scenario where I needed it is quite narrow (i.e. a row is removed from the data).