### PR TITLE
leaf pages should have buildPage false

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "syrinx"
-version = "0.0.14"
+version = "0.0.15"
 authors = [
   {name="Jasper van den Bosch"},
   {name="Dan Brady"},

--- a/syrinx/read.py
+++ b/syrinx/read.py
@@ -89,6 +89,7 @@ def read(root_dir: str, config: SyrinxConfiguration) -> ContentNode:
 
             if name == 'index':
                 node = indexNode
+                node.buildPage = True
             else:
                 node = ContentNode(meta, config)
                 node.name = name
@@ -100,7 +101,6 @@ def read(root_dir: str, config: SyrinxConfiguration) -> ContentNode:
             node.content_html = markdown(md_content)
             if 'SequenceNumber' in fm_dict:
                 node.sequenceNumber = fm_dict['SequenceNumber']
-            node.buildPage = True
             rel_path = join(dirpath.replace(content_dir, ""), fname)
             logger.info(f'Read {rel_path}')
 

--- a/tests/read.py
+++ b/tests/read.py
@@ -36,6 +36,21 @@ class ReadTests(TestCase):
         self.assertFalse(root.branches[0].buildPage)
 
     @patch('syrinx.read.walk')
+    @patch('syrinx.read.read_file')
+    def test_read_BuildPage_leaf(self, read_file, walk):
+        """Set "BuildPage" to false for leaves
+        """
+        read_file.return_value = dict(), ''
+        walk.return_value = [
+            ('/pth/content', None, ['index.md']),
+            ('/pth/content/lorem', None, ['ipsum.md', 'index.md']),
+        ]
+        config = Mock()
+        from syrinx.read import read
+        root = read('/pth', config)
+        self.assertFalse(root.branches[0].leaves[0].buildPage)
+
+    @patch('syrinx.read.walk')
     def test_read_Fail_if_index_missing(self, walk):
         """The root index.md is not optional,
         raise an exception if it's missing.


### PR DESCRIPTION
Syrinx doesn't build pages from "leaves", i.e. content pages that are not `index.md`. However, the `node.buildPage` attribute did not accurately reflect that.